### PR TITLE
Include rainbow colors for argument separators within parentheses.

### DIFF
--- a/autoload/rainbow_parentheses.vim
+++ b/autoload/rainbow_parentheses.vim
@@ -166,6 +166,7 @@ function! rainbow_parentheses#activate(...)
   for level in range(1, s:max_level)
     let col = colors[(level - 1) % len(colors)]
     execute printf('hi rainbowParensShell%d %s', s:max_level - level + 1, col)
+    execute printf('hi rainbowArgSeps%d %s', s:max_level - level + 1, col)
   endfor
   call s:regions(s:max_level)
 
@@ -204,6 +205,7 @@ endfunction
 function! s:regions(max)
   let pairs = get(g:, 'rainbow#pairs', [['(',')']])
   for level in range(1, a:max)
+    execute printf('syntax match rainbowArgSeps%d %s containedin=rainbowParens%d contained', level, '_,_', level)
     let cmd = 'syntax region rainbowParens%d matchgroup=rainbowParensShell%d start=/%s/ end=/%s/ contains=%s'
     let children = extend(['TOP'], map(range(level, a:max), '"rainbowParens".v:val'))
     for pair in pairs


### PR DESCRIPTION
I'm unaware of any languages that separate their function arguments with something other than commas or spaces, though this hard-coded comma can be pulled out as a configurable variable if need be.

The screenshot below reflects the behaviour changes with respect to comma-delimited argument separators:
![screenshot from 2017-01-07 03-56-30](https://cloud.githubusercontent.com/assets/4329951/21741516/55360d0e-d48d-11e6-8f34-2cc6bd96251a.png)